### PR TITLE
feat: allow package devs to specify aliases when register the app

### DIFF
--- a/demo/app.el
+++ b/demo/app.el
@@ -1,8 +1,8 @@
 (require 'cloel)
 
-(defvar cloel-demo-clj-file (expand-file-name "app.clj" (file-name-directory load-file-name)))
+(defvar cloel-demo-dir (file-name-directory load-file-name))
 
-(cloel-register-app "demo" cloel-demo-clj-file)
+(cloel-register-app "demo" cloel-demo-dir "cloel")
 
 (defun cloel-demo-test ()
   (interactive)
@@ -18,4 +18,4 @@
   ;; STEP 8: Call Clojure method "clojure.core/+" SYNC.
   (message "Got sync result of (+ 1 2 3): %s" (cloel-demo-call-sync "clojure.core/+" 1 2 3))
   ;; STEP 9: Call Clojure method "app-success" ASYNC.
-  (cloel-demo-call-async "app-success" "Cloel rocks!"))
+  (cloel-demo-call-async 'app/app-success "Cloel rocks!"))

--- a/demo/deps.edn
+++ b/demo/deps.edn
@@ -1,1 +1,6 @@
-{:deps {io.github.manateelazycat.cloel/cloel {:mvn/version "1.0.0"}}}
+{:deps {io.github.manateelazycat.cloel/cloel {:mvn/version "1.0.0"}}
+
+ :paths ["src"]
+
+ :aliases
+ {:cloel {:main-opts ["-m" "app"]}}}

--- a/demo/src/app.clj
+++ b/demo/src/app.clj
@@ -17,8 +17,7 @@
       ;; STEP 6: Get Elisp variable SYNC.
       (println "Value of 'user-full-name' is:" (cloel/elisp-get-var "user-full-name"))
       ;; STEP 7: Call Elisp method "cloel-demo-hello-confirm" ASYNC.
-      (cloel/elisp-eval-async "cloel-demo-hello-confirm")
-      )))
+      (cloel/elisp-eval-async "cloel-demo-hello-confirm"))))
 
 (defn app-success [message]
   ;; STEP 10: Send message to Emacs ASYNC.
@@ -27,4 +26,5 @@
 (alter-var-root #'cloel/handle-client-message (constantly app-handle-client-message))
 (alter-var-root #'cloel/handle-client-connected (constantly app-handle-client-connected))
 
-(cloel/start-server (Integer/parseInt (first *command-line-args*)))
+(defn -main [& args]
+  (cloel/start-server (Integer/parseInt (last args))))


### PR DESCRIPTION
BREAKING CHANGE: register fn changed

allow package devs to specify aliases when register the app

so that dev can set various opts in aliases
for example, `:jvm-opts` https://clojure.org/reference/deps_edn#aliases_jvmopts

related docs in fn and README are not changed yet