### PR TITLE
feat: add cloel.repl to generate .cloel-port file at dev time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ workspace/
 .lsp
 .cpcache
 target
+.nrepl-port
+.cloel-port

--- a/cloel.el
+++ b/cloel.el
@@ -252,6 +252,15 @@
                                        (format "*cloel-%s-client*" app-name)
                                        host port-num)))
     (cloel-set-app-data app-name :tcp-channel channel)
+
+    ;; TODO: this is ugly
+    ;; use channel as server-process when port file exists
+    ;; so that process-live-p against :server-process works
+    (let ((app-data (cloel-get-app-data app-name)))
+      (when (and (plist-get app-data :port-from-file)
+                 (not (plist-get app-data :server-process)))
+        (cloel-set-app-data app-name :server-process channel)))
+
     (set-process-coding-system channel 'utf-8 'utf-8)
     (if (process-live-p channel)
         (progn

--- a/cloel.el
+++ b/cloel.el
@@ -138,6 +138,7 @@
   "Register an app with APP-NAME and APP-FILE."
   (puthash app-name
            (list :dir app-dir
+                 :port-from-file (cloel-get-free-port-from-port-file)
                  :aliases aliases
                  :server-process nil
                  :tcp-channel nil)
@@ -153,6 +154,14 @@
   (when-let ((app-data (cloel-get-app-data app-name)))
     (puthash app-name (plist-put app-data key value) cloel-apps)))
 
+(defun cloel-get-free-port-from-port-file ()
+  "Get port specified in .cloel-port file."
+  (let ((port-file (expand-file-name ".cloel-port" default-directory)))
+    (when (file-exists-p port-file)
+      (with-temp-buffer
+        (insert-file-contents port-file)
+        (string-to-number (buffer-string))))))
+
 (defun cloel-get-free-port ()
   "Find a free port."
   (let ((process (make-network-process :name "cloel-port-finder"
@@ -165,31 +174,34 @@
 (defun cloel-start-process (app-name)
   "Start the Clojure server process for APP-NAME."
   (let* ((app-data (cloel-get-app-data app-name))
-         (app-dir (plist-get app-data :dir))
-         (app-aliases (or (plist-get app-data :aliases) "cloel"))
-         ;; We need change `default-directory' to application directory,
-         ;; otherwise `clojure' cannot found file `deps.edn' to load dependencies.
-         (default-directory app-dir)
-         (app-deps-edn (expand-file-name "deps.edn"))
-         (port (cloel-get-free-port)))
-    (unless (file-exists-p app-deps-edn)
-      (error "Cannot find app deps.edn at %s" app-deps-edn))
-    (let ((process (start-process (format "cloel-%s-clojure-server" app-name)
-                                  (format "*cloel-%s-clojure-server*" app-name)
-                                  ;; It's important to use "sh -c",
-                                  ;; otherwise ENV CLASSPATH is wrong
-                                  ;; clojure will throw error that cannot found clojure.core library
-                                  "sh"
-                                  "-c"
-                                  (format "clojure -M%s %d"
-                                          app-aliases
-                                          port))))
-      (cloel-set-app-data app-name :server-process process)
-      (message "Starting Clojure server for %s on port %d" app-name port)
-      (set-process-sentinel process
-                            (lambda (proc event)
-                              (cloel-server-process-sentinel proc event app-name)))
-      (cloel-connect-with-retry app-name "localhost" port))))
+         (port (plist-get app-data :port-from-file)))
+    (if port
+        (cloel-connect-with-retry app-name "localhost" port)
+      (let* ((app-dir (plist-get app-data :dir))
+             (app-aliases (or (plist-get app-data :aliases) "cloel"))
+             ;; We need change `default-directory' to application directory,
+             ;; otherwise `clojure' cannot found file `deps.edn' to load dependencies.
+             (default-directory app-dir)
+             (app-deps-edn (expand-file-name "deps.edn"))
+             (port (cloel-get-free-port)))
+        (unless (file-exists-p app-deps-edn)
+          (error "Cannot find app deps.edn at %s" app-deps-edn))
+        (let ((process (start-process (format "cloel-%s-clojure-server" app-name)
+                                      (format "*cloel-%s-clojure-server*" app-name)
+                                      ;; It's important to use "sh -c",
+                                      ;; otherwise ENV CLASSPATH is wrong
+                                      ;; clojure will throw error that cannot found clojure.core library
+                                      "sh"
+                                      "-c"
+                                      (format "clojure -M%s %d"
+                                              app-aliases
+                                              port))))
+          (cloel-set-app-data app-name :server-process process)
+          (message "Starting Clojure server for %s on port %d" app-name port)
+          (set-process-sentinel process
+                                (lambda (proc event)
+                                  (cloel-server-process-sentinel proc event app-name)))
+          (cloel-connect-with-retry app-name "localhost" port))))))
 
 (defun cloel-stop-process (app-name)
   "Stop the Clojure server process and disconnect the client for APP-NAME."

--- a/demo/.dir-locals.el
+++ b/demo/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((nil . ((cider-clojure-cli-aliases . "dev"))))

--- a/demo/app.el
+++ b/demo/app.el
@@ -1,8 +1,8 @@
 (require 'cloel)
 
-(defvar cloel-demo-clj-file (expand-file-name "app.clj" (file-name-directory load-file-name)))
+(defvar cloel-demo-dir (file-name-directory load-file-name))
 
-(cloel-register-app "demo" cloel-demo-clj-file)
+(cloel-register-app "demo" cloel-demo-dir "cloel")
 
 (defun cloel-demo-test ()
   (interactive)
@@ -18,4 +18,4 @@
   ;; STEP 8: Call Clojure method "clojure.core/+" SYNC.
   (message "Got sync result of (+ 1 2 3): %s" (cloel-demo-call-sync "clojure.core/+" 1 2 3))
   ;; STEP 9: Call Clojure method "app-success" ASYNC.
-  (cloel-demo-call-async "app-success" "Cloel rocks!"))
+  (cloel-demo-call-async 'app/app-success "Cloel rocks!"))

--- a/demo/deps.edn
+++ b/demo/deps.edn
@@ -3,4 +3,5 @@
  :paths ["src"]
 
  :aliases
- {:cloel {:main-opts ["-m" "app"]}}}
+ {:cloel {:main-opts ["-m" "app"]}
+  :dev   {:extra-paths ["dev"]}}}

--- a/demo/deps.edn
+++ b/demo/deps.edn
@@ -1,1 +1,6 @@
-{:deps {io.github.manateelazycat.cloel/cloel {:mvn/version "1.0.0"}}}
+{:deps {io.github.manateelazycat.cloel/cloel {:mvn/version "1.0.0"}}
+
+ :paths ["src"]
+
+ :aliases
+ {:cloel {:main-opts ["-m" "app"]}}}

--- a/demo/dev/user.clj
+++ b/demo/dev/user.clj
@@ -1,0 +1,14 @@
+(ns user
+  (:require cloel.repl))
+
+(defn start []
+  (cloel.repl/start-server))
+
+(defn stop []
+  (cloel.repl/stop-server))
+
+(start)
+
+(comment
+  (start)
+  (stop))

--- a/demo/src/app.clj
+++ b/demo/src/app.clj
@@ -17,8 +17,7 @@
       ;; STEP 6: Get Elisp variable SYNC.
       (println "Value of 'user-full-name' is:" (cloel/elisp-get-var "user-full-name"))
       ;; STEP 7: Call Elisp method "cloel-demo-hello-confirm" ASYNC.
-      (cloel/elisp-eval-async "cloel-demo-hello-confirm")
-      )))
+      (cloel/elisp-eval-async "cloel-demo-hello-confirm"))))
 
 (defn app-success [message]
   ;; STEP 10: Send message to Emacs ASYNC.
@@ -27,4 +26,5 @@
 (alter-var-root #'cloel/handle-client-message (constantly app-handle-client-message))
 (alter-var-root #'cloel/handle-client-connected (constantly app-handle-client-connected))
 
-(cloel/start-server (Integer/parseInt (first *command-line-args*)))
+(defn -main [& args]
+  (cloel/start-server (Integer/parseInt (last args))))

--- a/src/cloel.clj
+++ b/src/cloel.clj
@@ -104,4 +104,5 @@
         (when (nil? @client-connection)
           (let [client-socket (.accept server-socket)]
             (future (handle-client client-socket))))))
-    (println "Waiting for client connection...")))
+    (println "Waiting for client connection...")
+    server-socket))

--- a/src/cloel/repl.clj
+++ b/src/cloel/repl.clj
@@ -1,0 +1,34 @@
+(ns cloel.repl
+  (:require
+   cloel
+   [clojure.java.io :as io])
+  (:import [java.net ServerSocket]))
+
+(def port-file-name ".cloel-port")
+
+(defn- random-available-port []
+  (with-open [socket (ServerSocket. 0)]
+    (.getLocalPort socket)))
+
+(def server (atom nil))
+
+(defn- delete-port-file []
+  (let [file (io/file port-file-name)]
+    (when (.exists file)
+      (io/delete-file file))))
+
+(defn stop-server []
+  (when-let [s @server]
+    (.close s)
+    (reset! server nil))
+  (delete-port-file))
+
+(defn start-server []
+  (stop-server)
+  (let [port (random-available-port)]
+    (spit port-file-name port)
+    (reset! server (cloel/start-server port))))
+
+(comment
+  (start-server)
+  (stop-server))


### PR DESCRIPTION
The first commit is the same one in #2 

- add helper function `cloel.repl/start-server`, `cloel.repl/stop-server`
- `cloel.repl/start-server` will create a `.cloel-port` file and start the server
- demonstrate them in `user` namespace at `demo/dev/user.clj`
- prefer the port specified in `.cloel-port` when `cloel-register-app`
- connect to already started Clojure process if `.cloel-port` file exists

this changes the workflow at dev time 
- before
  - user start Clojure process by evaluating Elisp code (register and start)
- after
  - user start Clojure process using the `dev` alias 
    - for Emacs user, that's `cider-jack-in` with `cider-clojure-cli-aliases` set to `"dev"`
  - user evaluates Elisp code

this enables users to have the power of the Clojure REPL